### PR TITLE
Add Dockerfile for Within The Noise challenge

### DIFF
--- a/Within The Noise/Dockerfile
+++ b/Within The Noise/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 9999
+
+CMD ["python", "server.py"]


### PR DESCRIPTION
Added a `Dockerfile` to the `Within The Noise` directory to allow containerization of the challenge server. The container uses `python:3.9-slim`, exposes port 9999, and executes `server.py` on startup.

---
*PR created automatically by Jules for task [6655939204967820679](https://jules.google.com/task/6655939204967820679) started by @DerpSpears*