### PR TITLE
Add Dockerfile for Within The Noise challenge

### DIFF
--- a/Within The Noise/Dockerfile
+++ b/Within The Noise/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY server.py .
+
+EXPOSE 9999
+
+CMD ["python", "server.py"]


### PR DESCRIPTION
Added a Dockerfile for the Within The Noise challenge server.
The Dockerfile uses python:3.9-slim and exposes port 9999.
Verified that the server runs and accepts connections.

---
*PR created automatically by Jules for task [14538736952067935912](https://jules.google.com/task/14538736952067935912) started by @DerpSpears*