### PR TITLE
Add Dockerfile for Within The Noise challenge

### DIFF
--- a/Within The Noise/Dockerfile
+++ b/Within The Noise/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY server.py .
+
+EXPOSE 9999
+
+CMD ["python", "server.py"]


### PR DESCRIPTION
Created a Dockerfile for the Within The Noise challenge using python:3.9-slim base image. The container runs server.py on port 9999.

---
*PR created automatically by Jules for task [808416360333056887](https://jules.google.com/task/808416360333056887) started by @DerpSpears*