### PR TITLE
Add Dockerfile for Within The Noise challenge

### DIFF
--- a/Within The Noise/Dockerfile
+++ b/Within The Noise/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY server.py .
+
+EXPOSE 9999
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python", "server.py"]


### PR DESCRIPTION
Added a Dockerfile for the 'Within The Noise' challenge.
- Base image: python:3.9-slim
- Exposes port 9999
- Copies server.py
- Sets PYTHONUNBUFFERED=1 environment variable.

---
*PR created automatically by Jules for task [1017090577422180602](https://jules.google.com/task/1017090577422180602) started by @DerpSpears*