### PR TITLE
Create Dockerfile for Within The Noise challenge

### DIFF
--- a/Within The Noise/Dockerfile
+++ b/Within The Noise/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1
+
+RUN useradd -m ctf
+
+COPY --chown=ctf:ctf server.py .
+
+USER ctf
+
+EXPOSE 9999
+
+CMD ["python", "server.py"]


### PR DESCRIPTION
Created a Dockerfile for the Within The Noise challenge server.
- Uses `python:3.9-slim` base image.
- Runs as non-root user `ctf`.
- Exposes port 9999.
- Sets `PYTHONUNBUFFERED=1` for immediate logging.

---
*PR created automatically by Jules for task [14837479735670893142](https://jules.google.com/task/14837479735670893142) started by @DerpSpears*